### PR TITLE
Fix snapcraft failure to launch with snapd>=2.54.3

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -22,6 +22,9 @@ jobs:
         - base: core20
           base_os: focal
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+        - base: core22
+          base_os: jammy
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -18,13 +18,13 @@ jobs:
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/ppc64le
         - base: core18
           base_os: bionic
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
         - base: core20
           base_os: focal
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
         - base: core22
           base_os: jammy
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        PLATFORMS=(linux/386 linux/amd64 linux/arm/v7 linux/ppc64le linux/s390x)
+        PLATFORMS=(linux/386 linux/amd64 linux/arm/v7 linux/ppc64le) # linux/s390x)
         BASES=(core core18 core20 core22)
 
         BUILD_MATRIX=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,31 +4,61 @@ on:
   pull_request:
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.matrix.outputs.build_matrix }}
+      test_matrix: ${{ steps.matrix.outputs.test_matrix }}
+    steps:
+    - name: Generate Build Matrix
+      id: matrix
+      run: |
+        PLATFORMS=(linux/386 linux/amd64 linux/arm/v7 linux/ppc64le linux/s390x)
+        BASES=(core core18 core20 core22)
+
+        BUILD_MATRIX=
+        TEST_MATRIX=
+
+        for platform in ${PLATFORMS[@]}; do
+          experimental=false
+          [ "$platform" = "linux/s390" ] && experimental=true
+          case $platform in
+            linux/386)
+              channel=5.x/stable
+              ;;
+            *)
+              channel=latest/candidate
+              ;;
+          esac
+          for base in ${BASES[@]}; do
+            [ "$platform" = "linux/386" ]    && [ "$base" != "core" ]  && [ "$base" != "core18" ] && continue
+            [ "$platform" = "linux/s390" ]   && [ "$base" = "core" ]   && continue 
+            [ "$platform" = "linux/s390" ]   && [ "$base" = "core18" ] && continue
+            # armv7 and core20 is broken
+            [ "$platform" = "linux/arm/v7" ] && [ "$base" = "core20" ] && continue
+            case $base in
+              core)
+                os=xenial; ;;
+              core18)
+                os=bionic; ;;
+              core20)
+                os=focal; ;;
+              core22)
+                os=jammy; ;;
+            esac
+            BUILD_MATRIX="${BUILD_MATRIX:+$BUILD_MATRIX,}{\"platform\":\"$platform\",\"base\":{\"snap\":\"$base\",\"os\":\"$os\"},\"experimental\":$experimental}"
+            TEST_MATRIX="${TEST_MATRIX:+$TEST_MATRIX,}{\"platform\":\"$platform\",\"channel\":\"$channel\",\"base\":\"$base\",\"experimental\":$experimental}"
+          done
+        done
+        echo "::echo::on"
+        echo "::set-output name=build_matrix::{\"include\":[$BUILD_MATRIX]}"
+        echo "::set-output name=test_matrix::{\"include\":[$TEST_MATRIX]}"
+      
   build:
     runs-on: ubuntu-latest
+    needs: generate-matrix
     strategy:
-      matrix:
-        platform:
-        - linux/amd64
-        - linux/arm64
-        - linux/arm/v7
-        - linux/ppc64le
-        - linux/s390x
-        base:
-        - core
-        - core18
-        - core20
-        include:
-        - base: core
-          platform: linux/386
-        - base: core18
-          platform: linux/386
-        exclude:
-        - base: core
-          platform: linux/s390x
-        # ARMv7 is broken currently: https://bugs.launchpad.net/qemu/+bug/1886811
-        - base: core20
-          platform: linux/arm/v7
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.build_matrix) }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -40,15 +70,17 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        file: ./${{ matrix.base }}-stable.Dockerfile
+        file: ./Dockerfile
         platforms: ${{ matrix.platform }}
         tags: test-image
         push: false
         outputs: type=docker,dest=test-image.tar
+        build-args:
+          BASE_OS=${{ matrix.base.os }}
     - name: Save container image
       id: save_image
       run: |
-        echo ::set-output name=image_name::"$(echo "${{matrix.base}}-${{matrix.platform}}.tar" | sed 's|/|_|g')"
+        echo ::set-output name=image_name::"$(echo "${{matrix.base.snap}}-${{matrix.platform}}.tar" | sed 's|/|_|g')"
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.save_image.outputs.image_name }}
@@ -56,60 +88,10 @@ jobs:
 
   test-build-snap:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [ generate-matrix, build ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
-      matrix:
-        experimental: [false]
-        channel:
-        - latest/stable
-        - latest/candidate
-        platform:
-        - linux/amd64
-        - linux/arm64
-        - linux/arm/v7
-        - linux/ppc64le
-        base:
-        - core
-        - core18
-        - core20
-        
-        include:
-        - base: core
-          platform: linux/386
-          channel: latest/stable
-          experimental: false
-        - base: core
-          platform: linux/386
-          channel: latest/candidate
-          experimental: false
-        - base: core18
-          platform: linux/386
-          channel: latest/stable
-          experimental: false
-        - base: core18
-          platform: linux/386
-          channel: latest/candidate
-          experimental: false
-        - base: core18
-          platform: linux/s390x
-          channel: latest/candidate
-          experimental: true
-        - base: core20
-          platform: linux/s390x
-          channel: latest/stable
-          experimental: true
-
-        exclude:
-        # ARMv7 is broken currently: https://bugs.launchpad.net/qemu/+bug/1886811
-        - base: core20
-          platform: linux/arm/v7
-          channel: latest/stable
-          experimental: false
-        - base: core20
-          platform: linux/arm/v7
-          channel: latest/candidate
-          experimental: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.test_matrix) }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -121,10 +103,6 @@ jobs:
       run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json > /dev/null
         sudo systemctl restart docker
-    - name: Disable conflicting AppArmor rules
-      run: |
-        sudo mv /etc/apparmor.d/usr.lib.snapd.snap-confine.real /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/disable/usr.lib.snapd.snap-confine.real
     - name: Load container image
       id: load_image
       run: |
@@ -138,68 +116,18 @@ jobs:
       run: |
         docker image load -i ./artifacts/test-image.tar
         docker run --rm --tty --privileged \
-          --volume "$GITHUB_WORKSPACE/tests/${{ matrix.base }}":"$GITHUB_WORKSPACE/tests/${{ matrix.base }}" \
-          --workdir "$GITHUB_WORKSPACE/tests/${{ matrix.base }}" \
+          --volume "$GITHUB_WORKSPACE/tests/${{ matrix.base }}":"/data" \
+          --workdir "/data" \
           --env USE_SNAPCRAFT_CHANNEL="${{ matrix.channel }}" \
           --platform "${{ matrix.platform }}" \
           test-image snapcraft
 
   test-set-channel:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [ generate-matrix, build ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
-      matrix:
-        experimental: [false]
-        channel:
-        - latest/stable
-        - latest/candidate
-        platform:
-        - linux/amd64
-        - linux/arm64
-        - linux/arm/v7
-        - linux/ppc64le
-        base:
-        - core
-        - core18
-        - core20
-        
-        include:
-        - base: core
-          platform: linux/386
-          channel: latest/stable
-          experimental: false
-        - base: core
-          platform: linux/386
-          channel: latest/candidate
-          experimental: false
-        - base: core18
-          platform: linux/386
-          channel: latest/stable
-          experimental: false
-        - base: core18
-          platform: linux/386
-          channel: latest/candidate
-          experimental: false
-        - base: core18
-          platform: linux/s390x
-          channel: latest/candidate
-          experimental: true
-        - base: core20
-          platform: linux/s390x
-          channel: latest/stable
-          experimental: true
-
-        exclude:
-        # ARMv7 is broken currently: https://bugs.launchpad.net/qemu/+bug/1886811
-        - base: core20
-          platform: linux/arm/v7
-          channel: latest/stable
-          experimental: false
-        - base: core20
-          platform: linux/arm/v7
-          channel: latest/candidate
-          experimental: false
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.test_matrix) }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -211,10 +139,6 @@ jobs:
       run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json > /dev/null
         sudo systemctl restart docker
-    - name: Disable conflicting AppArmor rules
-      run: |
-        sudo mv /etc/apparmor.d/usr.lib.snapd.snap-confine.real /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/disable/usr.lib.snapd.snap-confine.real
     - name: Load container image
       id: load_image
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
       container=docker \
       init=/lib/systemd/systemd
 
+
 RUN apt-get update -qq && \
       apt-get dist-upgrade --yes && \
       apt-get install --yes -qq --no-install-recommends \
@@ -50,7 +51,8 @@ RUN apt-get update -qq && \
       systemctl enable snapd.service && \
       systemctl enable snapd.socket
 
-COPY entrypoint.sh /bin/
+ADD entrypoint.sh /bin/
+ADD systemd-detect-virt /usr/bin/
 
 VOLUME ["/run", "/run/lock"]
 STOPSIGNAL SIGRTMIN+3

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@ These container images start systemd and execute the command line passed on invo
 
 You may override the entrypoint with the `--entrypoint` parameter if you need to run the container without starting systemd. Or you may drop to a shell with systemd running by setting the command to `bash`.
 
-These container images require you to pass `--privileged`, along with `--security-opt apparmor=":docker-snapcraft:unconfined"`.
-
-You also need to create a directory at `/sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft`. This will initialise an empty AppArmor namespace. Once you've finished you can `rmdir` that same directory (it _must_ be `rmdir`, because `rm -r` and `rm -rf` won't work)
+These container images require you to pass `--privileged`.
 
 Note
 ----
 Currently there is an issue with the combination of Core20 and running this image through qemu emulating ARMv7, such as when running on GitHub Actions. See [the bug on Launchpad.net](https://bugs.launchpad.net/qemu/+bug/1886811) for the root cause.
+
+Previous instructions, based on earlier iterations of the container images, required you to create
+and use an AppArmor namespace - this is not necessary any more.  That is, you no-longer need to create a separate AppArmor namespace directory at
+`/sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft` and you can drop the
+`--security-opt apparmor=":docker-snapcraft:unconfined"` parameter from your `docker` command line.
 
 Running snapcraft
 -----------------
@@ -16,33 +19,25 @@ Running snapcraft
 Running without specifying a command will run `snapcraft` without any parameters:
 
 ```bash
-sudo mkdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
-docker run --rm -it --privileged --security-opt apparmor=":docker-snapcraft:unconfined" -v $PWD:/data -w /data diddledan/snapcraft:core18
-sudo rmdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
+docker run --rm -it --privileged -v $PWD:/data -w /data diddledan/snapcraft:core18
 ```
 
 To run with parameters, specify `snapcraft [...params]` when creating the container:
 
 ```bash
-sudo mkdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
-docker run --rm -it --privileged --security-opt apparmor=":docker-snapcraft:unconfined" -v $PWD:/data -w /data diddledan/snapcraft:core18 snapcraft stage --enable-experimental-package-repositories
-sudo rmdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
+docker run --rm -it --privileged -v $PWD:/data -w /data diddledan/snapcraft:core18 snapcraft stage --enable-experimental-package-repositories
 ```
 
 Drop to a shell with systemd running
 ------------------------------------
 
 ```bash
-sudo mkdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
-docker run --rm -it --privileged --security-opt apparmor=":docker-snapcraft:unconfined" -v $PWD:/data -w /data diddledan/snapcraft:core18 bash
-sudo rmdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
+docker run --rm -it --privileged -v $PWD:/data -w /data diddledan/snapcraft:core18 bash
 ```
 
 Drop to a shell without starting systemd
 ----------------------------------------
 
 ```bash
-sudo mkdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
-docker run --rm -it --privileged --security-opt apparmor=":docker-snapcraft:unconfined" -v $PWD:/data -w /data --entrypoint bash diddledan/snapcraft:core18
-sudo rmdir /sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft
+docker run --rm -it --privileged -v $PWD:/data -w /data --entrypoint bash diddledan/snapcraft:core18
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,7 @@ ExecStartPre=/bin/rm -f /.dockerenv /run/.containerenv
 ExecStartPre=/usr/bin/snap install snapcraft --classic --channel $USE_SNAPCRAFT_CHANNEL
 ExecStart=/usr/local/bin/docker_commandline.sh
 Environment="SNAPCRAFT_BUILD_ENVIRONMENT=host"
+Environment="SNAPPY_LAUNCHER_INSIDE_TESTS=true"
 Environment="LANG=C.UTF-8"
 Restart=no
 Type=oneshot
@@ -68,4 +69,6 @@ WantedBy=default.target
 EOF
 
 "$systemctl" enable docker-exec.service
+
+mount -o rw,nosuid,nodev,noexec,relatime securityfs -t securityfs /sys/kernel/security
 exec /lib/systemd/systemd

--- a/systemd-detect-virt
+++ b/systemd-detect-virt
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$1" != "--quiet" ]; then
+    echo -n wsl
+fi
+

--- a/tests/core/snap/snapcraft.yaml
+++ b/tests/core/snap/snapcraft.yaml
@@ -2,9 +2,9 @@ name: core-test
 version: '0.1'
 summary: Summary of the simple snap
 description: Description of the simple snap
-architectures: [all]
 confinement: strict
 base: core
+grade: devel
 
 parts:
   dummy-part:

--- a/tests/core20/snap/snapcraft.yaml
+++ b/tests/core20/snap/snapcraft.yaml
@@ -2,9 +2,9 @@ name: core20-test
 version: '0.1'
 summary: Summary of the simple snap
 description: Description of the simple snap
-architectures: [all]
 confinement: strict
 base: core20
+grade: devel
 
 parts:
   dummy-part:

--- a/tests/core22/snap/snapcraft.yaml
+++ b/tests/core22/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
-name: core18-test
+name: core22-test
 version: '0.1'
 summary: Summary of the simple snap
 description: Description of the simple snap
 confinement: strict
-base: core18
+base: core22
 grade: devel
 
 parts:


### PR DESCRIPTION
* Force `systemd-detect-virt` to always return `wsl` to circumvent snapd
  checks.
* Update README.md instructions to remove `--security-opt` parameter
  which is no-longer required.
* Update README.md instructions to remove creation and deletion of
  AppArmor namespace directory in
  `/sys/security/apparmor/policy/namespaces`
* Add `core22` container image to automated build process
* Update automated tests to match the reduced execution steps
* Add `core22` to automated testsuite

Fixes #8

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>