### PR TITLE
Add build-essential to container images during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update -qq && \
 	apt-get dist-upgrade --yes && \
 	apt-get install --yes -qq --no-install-recommends \
+		build-essential \
 		fuse \
 		gnupg \
 		python3 \


### PR DESCRIPTION
Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>