### PR TITLE
Refinements to Dockerfile and entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 ARG BASE_OS=xenial
 
+# Download and repack snapd with a replacement squashfs-tools to
+# fix a bug with mksquashfs when packing a built snap.
+# See: https://bugs.launchpad.net/snapd/+bug/1733598
 FROM ubuntu:xenial as snapd
-ENV DEBIAN_FRONTEND=noninteractive \
-	LDFLAGS=-static
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LDFLAGS=-static
+
+# Run apt-get commands together to always ensure apt-get update is run
+# before using apt-get install to avoid issues with stale apt caches.
 RUN apt-get update -qq && \
 	apt-get dist-upgrade --yes && \
 	apt-get install --yes -qq --no-install-recommends \
@@ -19,10 +25,11 @@ RUN apt-get update -qq && \
 		zlib1g-dev \
 		liblz4-dev \
 		liblzma-dev \
-		liblzo2-dev \
-	&& \
-	git clone https://github.com/plougher/squashfs-tools.git && \
-	cd squashfs-tools && \
+		liblzo2-dev
+
+# Fetch and compile squashfs-tools
+RUN git clone https://github.com/plougher/squashfs-tools.git
+RUN cd squashfs-tools && \
 	git checkout 4.5.1 && \
 	sed -Ei 's/#(XZ_SUPPORT.*)/\1/' squashfs-tools/Makefile && \
 	sed -Ei 's/#(LZO_SUPPORT.*)/\1/' squashfs-tools/Makefile && \
@@ -31,21 +38,28 @@ RUN apt-get update -qq && \
 	sed -Ei 's/\$\(INSTALL_DIR\)/$(DESTDIR)$(INSTALL_DIR)/g' squashfs-tools/Makefile && \
 	cd squashfs-tools && \
 	make -j$(nproc) && \
-	make install && \
-	mkdir -p /snap/snapd/current && \
-	snap download snapd && \
-	unsquashfs -f -d /snap/snapd/current snapd_*.snap && \
-	cp /usr/bin/mksquashfs /snap/snapd/current/usr/bin && \
-	cp /usr/bin/unsquashfs /snap/snapd/current/usr/bin && \
-	mksquashfs /snap/snapd/current /snapd.snap
+	make install
 
-FROM ubuntu:${BASE_OS}
+# Download and unpack snapd
+RUN mkdir -p /snap/snapd/current
+RUN snap download snapd
+RUN unsquashfs -f -d /snap/snapd/current snapd_*.snap
 
-# Set the proper environment.
-ENV DEBIAN_FRONTEND=noninteractive \
-	container=docker \
-	init=/lib/systemd/systemd
+# Replace mksquashfs and unsqusahfs with our own
+RUN cp /usr/bin/mksquashfs /snap/snapd/current/usr/bin
+RUN cp /usr/bin/unsquashfs /snap/snapd/current/usr/bin
 
+# Repack snapd
+RUN mksquashfs /snap/snapd/current /snapd.snap
+
+
+# Prepare the filesystem to copy into a blank image
+FROM ubuntu:${BASE_OS} as base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Run apt-get commands together to always ensure apt-get update is run
+# before using apt-get install to avoid issues with stale apt caches.
 RUN apt-get update -qq && \
 	apt-get dist-upgrade --yes && \
 	apt-get install --yes -qq --no-install-recommends \
@@ -55,47 +69,74 @@ RUN apt-get update -qq && \
 		python3 \
 		snapd \
 		sudo \
-		systemd \
-	&& \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists && \
-	touch /var/lib/snapd/system-key && \
+		systemd
+
+# Clean apt lists because we'll be copying the entire filesystem to a blank image
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists
+
+# Ensure snapd's system-key file exists
+RUN touch /var/lib/snapd/system-key
+
 # stop udevadm from working
-  dpkg-divert --local --rename --add /sbin/udevadm && \
-  ln -s /bin/true /sbin/udevadm && \
+RUN dpkg-divert --local --rename --add /sbin/udevadm
+RUN ln -s /bin/true /sbin/udevadm
+
 # remove systemd 'wants' triggers
-	rm -f \
+RUN rm -f \
 		/etc/systemd/system/*.wants/* \
 		/lib/systemd/system/local-fs.target.wants/* \
 		/lib/systemd/system/multi-user.target.wants/* \
-		/lib/systemd/system/sockets.target.wants/*initctl* \
-		&& \
+		/lib/systemd/system/sockets.target.wants/*initctl*
+
 # remove everything except tmpfiles setup in sysinit target
-	find \
+RUN find \
 		/lib/systemd/system/sysinit.target.wants \
 		\( -type f -or -type l \) -and -not -name '*systemd-tmpfiles-setup*' \
-		-delete && \
-# remove UTMP updater service
-	rm -f /lib/systemd/system/systemd-update-utmp-runlevel.service && \
-# disable /tmp mount
-	rm -vf /usr/share/systemd/tmp.mount && \
-# disable most systemd console output
-	echo ShowStatus=no >> /etc/systemd/system.conf && \
-# disable ondemand.service
-	systemctl disable ondemand.service && \
-# set basic.target as default
-	systemctl set-default basic.target && \
-# enable the services we care about
-	systemctl enable snapd.service && \
-	systemctl enable snapd.socket
+		-delete
 
+# remove UTMP updater service
+RUN rm -f /lib/systemd/system/systemd-update-utmp-runlevel.service
+
+# disable /tmp mount
+RUN rm -vf /usr/share/systemd/tmp.mount
+
+# disable most systemd console output
+RUN echo ShowStatus=no >> /etc/systemd/system.conf
+
+# disable ondemand.service
+RUN systemctl disable ondemand.service
+
+# set basic.target as default
+RUN systemctl set-default basic.target
+
+# enable the services we care about
+RUN systemctl enable snapd.service
+RUN systemctl enable snapd.socket
+
+
+# The actual snapcraft image
+FROM scratch
+
+# Set the proper environment.
+ENV container=docker \
+	init=/lib/systemd/systemd
+
+# Copy the entire filesystem from the base image
+COPY --from=base / /
+
+# Copy the snapd snap from the snapd image
 COPY --from=snapd /snapd.snap /snapd.snap
+
+# Add our entrypoint
 ADD entrypoint.sh /bin/
 ADD systemd-detect-virt /usr/bin/
 
-VOLUME ["/run", "/run/lock"]
+# Ensure docker sends the shutdown signal that systemd expects
 STOPSIGNAL SIGRTMIN+3
 
+# Set our entrypoint
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
+# Set our default command
 CMD ["snapcraft"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,8 +79,8 @@ Wants=snapd.seeded.service
 After=snapd.service snapd.socket snapd.seeded.service
 
 [Service]
-ExecStartPre=bash -c '/usr/bin/snap install /snapd.snap --dangerous < /dev/null'
-ExecStartPre=bash -c '/usr/bin/snap install snapcraft --classic --channel $USE_SNAPCRAFT_CHANNEL < /dev/null'
+ExecStartPre=/bin/bash -c '/usr/bin/snap install /snapd.snap --dangerous < /dev/null'
+ExecStartPre=/bin/bash -c '/usr/bin/snap install snapcraft --classic --channel $USE_SNAPCRAFT_CHANNEL < /dev/null'
 ExecStart=/usr/local/bin/docker_commandline.sh
 Environment="SNAPPY_LAUNCHER_INSIDE_TESTS=true"
 Environment="LANG=C.UTF-8"


### PR DESCRIPTION
* Attempt to make Dockerfile more understandable to passers-by (Ref: https://forum.snapcraft.io/t/build-on-docker/4158/32?u=diddledani)
* Ensure `--verbosity` flag is only added when running snapcraft
* Improve environment variable definitions and overrides
* Make `snap install` commands in `ExecPre` in the systemd unit file believe they're run without a controlling terminal to reduce output spew caused by 'spinners'
* Mount `/tmp`, `/run`, and `/run/lock` with tmpfs
* Some extra comments to explain things

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>